### PR TITLE
Fix pathes to public API headers

### DIFF
--- a/src/av1rtppacketizer.cpp
+++ b/src/av1rtppacketizer.cpp
@@ -8,7 +8,7 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "av1rtppacketizer.hpp"
+#include "rtc/av1rtppacketizer.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/candidate.cpp
+++ b/src/candidate.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "candidate.hpp"
+#include "rtc/candidate.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -6,8 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "rtc.h"
-#include "rtc.hpp"
+#include "rtc/rtc.h"
+#include "rtc/rtc.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "channel.hpp"
+#include "rtc/channel.hpp"
 
 #include "impl/channel.hpp"
 #include "impl/internals.hpp"

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "configuration.hpp"
+#include "rtc/configuration.hpp"
 
 #include "impl/utils.hpp"
 

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -6,9 +6,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "datachannel.hpp"
-#include "common.hpp"
-#include "peerconnection.hpp"
+#include "rtc/datachannel.hpp"
+#include "rtc/common.hpp"
+#include "rtc/peerconnection.hpp"
 
 #include "impl/datachannel.hpp"
 #include "impl/internals.hpp"

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -7,7 +7,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "description.hpp"
+#include "rtc/description.hpp"
 
 #include "impl/internals.hpp"
 #include "impl/utils.hpp"

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -14,7 +14,7 @@
 #include "plog/Log.h"
 #include "plog/Logger.h"
 //
-#include "global.hpp"
+#include "rtc/global.hpp"
 
 #include "impl/init.hpp"
 

--- a/src/h264rtppacketizer.cpp
+++ b/src/h264rtppacketizer.cpp
@@ -8,7 +8,7 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "h264rtppacketizer.hpp"
+#include "rtc/h264rtppacketizer.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/h265nalunit.cpp
+++ b/src/h265nalunit.cpp
@@ -8,7 +8,7 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "h265nalunit.hpp"
+#include "rtc/h265nalunit.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/h265rtppacketizer.cpp
+++ b/src/h265rtppacketizer.cpp
@@ -8,7 +8,7 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "h265rtppacketizer.hpp"
+#include "rtc/h265rtppacketizer.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/impl/certificate.hpp
+++ b/src/impl/certificate.hpp
@@ -9,9 +9,9 @@
 #ifndef RTC_IMPL_CERTIFICATE_H
 #define RTC_IMPL_CERTIFICATE_H
 
-#include "description.hpp" // for CertificateFingerprint
-#include "common.hpp"
-#include "configuration.hpp" // for CertificateType
+#include "rtc/description.hpp" // for CertificateFingerprint
+#include "rtc/common.hpp"
+#include "rtc/configuration.hpp" // for CertificateType
 #include "init.hpp"
 #include "tls.hpp"
 

--- a/src/impl/channel.hpp
+++ b/src/impl/channel.hpp
@@ -9,8 +9,8 @@
 #ifndef RTC_IMPL_CHANNEL_H
 #define RTC_IMPL_CHANNEL_H
 
-#include "common.hpp"
-#include "message.hpp"
+#include "rtc/common.hpp"
+#include "rtc/message.hpp"
 
 #include <atomic>
 #include <functional>

--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "datachannel.hpp"
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "internals.hpp"
 #include "logcounter.hpp"
 #include "peerconnection.hpp"

--- a/src/impl/datachannel.hpp
+++ b/src/impl/datachannel.hpp
@@ -10,11 +10,10 @@
 #define RTC_IMPL_DATA_CHANNEL_H
 
 #include "channel.hpp"
-#include "common.hpp"
-#include "message.hpp"
-#include "peerconnection.hpp"
+#include "rtc/common.hpp"
+#include "rtc/message.hpp"
 #include "queue.hpp"
-#include "reliability.hpp"
+#include "rtc/reliability.hpp"
 #include "sctptransport.hpp"
 
 #include <atomic>

--- a/src/impl/dtlssrtptransport.cpp
+++ b/src/impl/dtlssrtptransport.cpp
@@ -8,7 +8,7 @@
 
 #include "dtlssrtptransport.hpp"
 #include "logcounter.hpp"
-#include "rtp.hpp"
+#include "rtc/rtp.hpp"
 #include "tls.hpp"
 
 #if RTC_ENABLE_MEDIA

--- a/src/impl/dtlssrtptransport.hpp
+++ b/src/impl/dtlssrtptransport.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_DTLS_SRTP_TRANSPORT_H
 #define RTC_IMPL_DTLS_SRTP_TRANSPORT_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "dtlstransport.hpp"
 
 #if RTC_ENABLE_MEDIA

--- a/src/impl/dtlstransport.hpp
+++ b/src/impl/dtlstransport.hpp
@@ -10,7 +10,7 @@
 #define RTC_IMPL_DTLS_TRANSPORT_H
 
 #include "certificate.hpp"
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "queue.hpp"
 #include "tls.hpp"
 #include "transport.hpp"

--- a/src/impl/http.hpp
+++ b/src/impl/http.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_HTTP_H
 #define RTC_IMPL_HTTP_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 
 #include <list>
 #include <map>

--- a/src/impl/httpproxytransport.hpp
+++ b/src/impl/httpproxytransport.hpp
@@ -10,7 +10,7 @@
 #ifndef RTC_IMPL_TCP_PROXY_TRANSPORT_H
 #define RTC_IMPL_TCP_PROXY_TRANSPORT_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "transport.hpp"
 
 #if RTC_ENABLE_WEBSOCKET

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "icetransport.hpp"
-#include "configuration.hpp"
+#include "rtc/configuration.hpp"
 #include "internals.hpp"
 #include "transport.hpp"
 #include "utils.hpp"

--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -9,12 +9,11 @@
 #ifndef RTC_IMPL_ICE_TRANSPORT_H
 #define RTC_IMPL_ICE_TRANSPORT_H
 
-#include "candidate.hpp"
-#include "common.hpp"
-#include "configuration.hpp"
-#include "description.hpp"
-#include "global.hpp"
-#include "peerconnection.hpp"
+#include "rtc/candidate.hpp"
+#include "rtc/common.hpp"
+#include "rtc/configuration.hpp"
+#include "rtc/description.hpp"
+#include "rtc/global.hpp"
 #include "transport.hpp"
 
 #if !USE_NICE

--- a/src/impl/init.hpp
+++ b/src/impl/init.hpp
@@ -9,8 +9,8 @@
 #ifndef RTC_IMPL_INIT_H
 #define RTC_IMPL_INIT_H
 
-#include "common.hpp"
-#include "global.hpp" // for SctpSettings
+#include "rtc/common.hpp"
+#include "rtc/global.hpp" // for SctpSettings
 
 #include <chrono>
 #include <future>

--- a/src/impl/internals.hpp
+++ b/src/impl/internals.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_INTERNALS_H
 #define RTC_IMPL_INTERNALS_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 
 // Disable warnings before including plog
 #if defined(__GNUC__) || defined(__clang__)

--- a/src/impl/logcounter.hpp
+++ b/src/impl/logcounter.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_SERVER_LOGCOUNTER_HPP
 #define RTC_SERVER_LOGCOUNTER_HPP
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "threadpool.hpp"
 
 #include <atomic>

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -15,7 +15,7 @@
 #include "logcounter.hpp"
 #include "peerconnection.hpp"
 #include "processor.hpp"
-#include "rtp.hpp"
+#include "rtc/rtp.hpp"
 #include "sctptransport.hpp"
 #include "utils.hpp"
 

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_PEER_CONNECTION_H
 #define RTC_IMPL_PEER_CONNECTION_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "datachannel.hpp"
 #include "dtlstransport.hpp"
 #include "icetransport.hpp"

--- a/src/impl/pollinterrupter.hpp
+++ b/src/impl/pollinterrupter.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_POLL_INTERRUPTER_H
 #define RTC_IMPL_POLL_INTERRUPTER_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "socket.hpp"
 
 #if RTC_ENABLE_WEBSOCKET

--- a/src/impl/pollservice.hpp
+++ b/src/impl/pollservice.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_POLL_SERVICE_H
 #define RTC_IMPL_POLL_SERVICE_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "internals.hpp"
 #include "pollinterrupter.hpp"
 #include "socket.hpp"

--- a/src/impl/processor.hpp
+++ b/src/impl/processor.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_PROCESSOR_H
 #define RTC_IMPL_PROCESSOR_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "queue.hpp"
 #include "threadpool.hpp"
 

--- a/src/impl/queue.hpp
+++ b/src/impl/queue.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_QUEUE_H
 #define RTC_IMPL_QUEUE_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 
 #include <atomic>
 #include <chrono>

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -9,9 +9,9 @@
 #ifndef RTC_IMPL_SCTP_TRANSPORT_H
 #define RTC_IMPL_SCTP_TRANSPORT_H
 
-#include "common.hpp"
-#include "configuration.hpp"
-#include "global.hpp"
+#include "rtc/common.hpp"
+#include "rtc/configuration.hpp"
+#include "rtc/global.hpp"
 #include "processor.hpp"
 #include "queue.hpp"
 #include "transport.hpp"

--- a/src/impl/sha.hpp
+++ b/src/impl/sha.hpp
@@ -11,7 +11,7 @@
 
 #if RTC_ENABLE_WEBSOCKET
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 
 namespace rtc::impl {
 

--- a/src/impl/tcpserver.hpp
+++ b/src/impl/tcpserver.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_TCP_SERVER_H
 #define RTC_IMPL_TCP_SERVER_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "pollinterrupter.hpp"
 #include "queue.hpp"
 #include "socket.hpp"

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_TCP_TRANSPORT_H
 #define RTC_IMPL_TCP_TRANSPORT_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "pollservice.hpp"
 #include "queue.hpp"
 #include "socket.hpp"

--- a/src/impl/threadpool.hpp
+++ b/src/impl/threadpool.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_THREADPOOL_H
 #define RTC_IMPL_THREADPOOL_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "init.hpp"
 #include "internals.hpp"
 

--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_TLS_H
 #define RTC_TLS_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 
 #include <chrono>
 

--- a/src/impl/tlstransport.hpp
+++ b/src/impl/tlstransport.hpp
@@ -10,7 +10,7 @@
 #define RTC_IMPL_TLS_TRANSPORT_H
 
 #include "certificate.hpp"
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "queue.hpp"
 #include "tls.hpp"
 #include "transport.hpp"

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -10,7 +10,7 @@
 #include "internals.hpp"
 #include "logcounter.hpp"
 #include "peerconnection.hpp"
-#include "rtp.hpp"
+#include "rtc/rtp.hpp"
 
 namespace rtc::impl {
 

--- a/src/impl/track.hpp
+++ b/src/impl/track.hpp
@@ -10,9 +10,9 @@
 #define RTC_IMPL_TRACK_H
 
 #include "channel.hpp"
-#include "common.hpp"
-#include "description.hpp"
-#include "mediahandler.hpp"
+#include "rtc/common.hpp"
+#include "rtc/description.hpp"
+#include "rtc/mediahandler.hpp"
 #include "queue.hpp"
 
 #if RTC_ENABLE_MEDIA

--- a/src/impl/transport.hpp
+++ b/src/impl/transport.hpp
@@ -9,10 +9,10 @@
 #ifndef RTC_IMPL_TRANSPORT_H
 #define RTC_IMPL_TRANSPORT_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "init.hpp"
 #include "internals.hpp"
-#include "message.hpp"
+#include "rtc/message.hpp"
 
 #include <atomic>
 #include <functional>

--- a/src/impl/utils.cpp
+++ b/src/impl/utils.cpp
@@ -8,7 +8,7 @@
 
 #include "utils.hpp"
 
-#include "impl/internals.hpp"
+#include "internals.hpp"
 
 #include <algorithm>
 #include <cctype>

--- a/src/impl/utils.hpp
+++ b/src/impl/utils.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_UTILS_H
 #define RTC_IMPL_UTILS_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 
 #include <climits>
 #include <limits>

--- a/src/impl/verifiedtlstransport.cpp
+++ b/src/impl/verifiedtlstransport.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "verifiedtlstransport.hpp"
-#include "common.hpp"
+#include "rtc/common.hpp"
 
 #if RTC_ENABLE_WEBSOCKET
 

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -9,7 +9,7 @@
 #if RTC_ENABLE_WEBSOCKET
 
 #include "websocket.hpp"
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "internals.hpp"
 #include "processor.hpp"
 #include "utils.hpp"

--- a/src/impl/websocket.hpp
+++ b/src/impl/websocket.hpp
@@ -12,10 +12,10 @@
 #if RTC_ENABLE_WEBSOCKET
 
 #include "channel.hpp"
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "httpproxytransport.hpp"
 #include "init.hpp"
-#include "message.hpp"
+#include "rtc/message.hpp"
 #include "queue.hpp"
 #include "tcptransport.hpp"
 #include "tlstransport.hpp"

--- a/src/impl/websocketserver.cpp
+++ b/src/impl/websocketserver.cpp
@@ -9,7 +9,7 @@
 #if RTC_ENABLE_WEBSOCKET
 
 #include "websocketserver.hpp"
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "internals.hpp"
 #include "threadpool.hpp"
 #include "utils.hpp"

--- a/src/impl/websocketserver.hpp
+++ b/src/impl/websocketserver.hpp
@@ -12,9 +12,9 @@
 #if RTC_ENABLE_WEBSOCKET
 
 #include "certificate.hpp"
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "init.hpp"
-#include "message.hpp"
+#include "rtc/message.hpp"
 #include "tcpserver.hpp"
 #include "websocket.hpp"
 

--- a/src/impl/wshandshake.hpp
+++ b/src/impl/wshandshake.hpp
@@ -9,7 +9,7 @@
 #ifndef RTC_IMPL_WS_HANDSHAKE_H
 #define RTC_IMPL_WS_HANDSHAKE_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 
 #if RTC_ENABLE_WEBSOCKET
 

--- a/src/impl/wstransport.hpp
+++ b/src/impl/wstransport.hpp
@@ -9,9 +9,9 @@
 #ifndef RTC_IMPL_WS_TRANSPORT_H
 #define RTC_IMPL_WS_TRANSPORT_H
 
-#include "common.hpp"
+#include "rtc/common.hpp"
 #include "transport.hpp"
-#include "configuration.hpp"
+#include "rtc/configuration.hpp"
 #include "wshandshake.hpp"
 
 #if RTC_ENABLE_WEBSOCKET

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "message.hpp"
+#include "rtc/message.hpp"
 
 namespace rtc {
 

--- a/src/nalunit.cpp
+++ b/src/nalunit.cpp
@@ -8,7 +8,7 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "nalunit.hpp"
+#include "rtc/nalunit.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -7,9 +7,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "peerconnection.hpp"
-#include "common.hpp"
-#include "rtp.hpp"
+#include "rtc/peerconnection.hpp"
+#include "rtc/common.hpp"
+#include "rtc/rtp.hpp"
 
 #include "impl/certificate.hpp"
 #include "impl/dtlstransport.hpp"

--- a/src/rtcpnackresponder.cpp
+++ b/src/rtcpnackresponder.cpp
@@ -8,8 +8,8 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "rtcpnackresponder.hpp"
-#include "rtp.hpp"
+#include "rtc/rtcpnackresponder.hpp"
+#include "rtc/rtp.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/rtcpreceivingsession.cpp
+++ b/src/rtcpreceivingsession.cpp
@@ -9,8 +9,8 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "rtcpreceivingsession.hpp"
-#include "track.hpp"
+#include "rtc/rtcpreceivingsession.hpp"
+#include "rtc/track.hpp"
 
 #include "impl/logcounter.hpp"
 

--- a/src/rtcpsrreporter.cpp
+++ b/src/rtcpsrreporter.cpp
@@ -8,7 +8,7 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "rtcpsrreporter.hpp"
+#include "rtc/rtcpsrreporter.hpp"
 
 #include <cassert>
 #include <chrono>

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -8,7 +8,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "rtp.hpp"
+#include "rtc/rtp.hpp"
 
 #include "impl/internals.hpp"
 

--- a/src/rtppacketizationconfig.cpp
+++ b/src/rtppacketizationconfig.cpp
@@ -8,7 +8,7 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "rtppacketizationconfig.hpp"
+#include "rtc/rtppacketizationconfig.hpp"
 
 #include "impl/utils.hpp"
 

--- a/src/rtppacketizer.cpp
+++ b/src/rtppacketizer.cpp
@@ -8,7 +8,7 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "rtppacketizer.hpp"
+#include "rtc/rtppacketizer.hpp"
 
 #include <cmath>
 #include <cstring>

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#include "track.hpp"
+#include "rtc/track.hpp"
 
 #include "impl/internals.hpp"
 #include "impl/track.hpp"

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -8,8 +8,8 @@
 
 #if RTC_ENABLE_WEBSOCKET
 
-#include "websocket.hpp"
-#include "common.hpp"
+#include "rtc/websocket.hpp"
+#include "rtc/common.hpp"
 
 #include "impl/internals.hpp"
 #include "impl/websocket.hpp"

--- a/src/websocketserver.cpp
+++ b/src/websocketserver.cpp
@@ -8,8 +8,8 @@
 
 #if RTC_ENABLE_WEBSOCKET
 
-#include "websocketserver.hpp"
-#include "common.hpp"
+#include "rtc/websocketserver.hpp"
+#include "rtc/common.hpp"
 
 #include "impl/internals.hpp"
 #include "impl/websocketserver.hpp"


### PR DESCRIPTION
Public API is expected to be referenced as ```<rtc/foo.hpp>```. Currently project sources reference public headers as simply "foo.hpp" without ```rtc/``` prefix. This makes difficult to visually trace which header - public or internal - is referenced. Also it may lead to circular includes when local/public header files have the same name e.g. ```datachannel.hpp``` or ```peerconnection.hpp```

No functional changes.